### PR TITLE
Added Logagent env vars to readme and values.yaml

### DIFF
--- a/charts/sematext-agent/Chart.yaml
+++ b/charts/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.32
+version: 1.0.33
 description: Helm chart for deploying Sematext Agent and Logagent to Kubernetes
 keywords:
   - sematext

--- a/charts/sematext-agent/README.md
+++ b/charts/sematext-agent/README.md
@@ -70,34 +70,41 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configuration parameters of the `sematext-agent` chart and default values.
 
-|             Parameter            |            Description            |                  Default                  |
-|----------------------------------|-----------------------------------|-------------------------------------------|
-| `containerToken`                 | Sematext Container token          | `Nil` Provide your Container token        |
-| `logsToken`                      | Sematext Logs token               | `Nil` Provide your Logs token             |
-| `infraToken`                     | Sematext Infra token              | `Nil` Provide your Infra token            |
-| `region`                         | Sematext region                   | `US` Sematext US or EU region             |
-| `agent.image.repository`         | The image repository              | `sematext/agent`                          |
-| `agent.image.tag`                | The image tag                     | `latest`                                  |
-| `agent.image.pullPolicy`         | Image pull policy                 | `Always`                                  |
-| `agent.service.port`             | Service port                      | `80`                                      |
-| `agent.service.type`             | Service type                      | `ClusterIP`                               |
-| `agent.resources`                | Agent resources                   | `{}`                                      |
-| `logagent.image.repository`      | The image repository              | `sematext/logagent`                       |
-| `logagent.image.tag`             | The image tag                     | `latest`                                  |
-| `logagent.image.pullPolicy`      | Image pull policy                 | `Always`                                  |
-| `logagent.resources`             | Logagent resources                | `{}`                                      |
-| `logagent.customConfigs`         | Logagent custom configs           | `[]` Check `values.yaml`                  |
-| `logagent.extraHostVolumeMounts` | Extra mounts                      | `{}`                                      |
-| `serviceAccount.create`          | Create a service account          | `true`                                    |
-| `serviceAccount.name`            | Service account name              | `Nil` Defaults to chart name              |
-| `priorityClassName`              | Priority class name               | `Nil`                                     |
-| `rbac.create`                    | RBAC enabled                      | `true`                                    |
-| `tolerations`                    | Tolerations                       | `[]`                                      |
-| `nodeSelector`                   | Node selector                     | `{}`                                      |
-| `serverBaseUrl`                  | Custom Base URL                   | `Nil`                                     |
-| `logsReceiverUrl`                | Custom Logs receiver URL          | `Nil`                                     |
-| `eventsReceiverUrl`              | Custom Event receiver URL         | `Nil`                                     |
-| `commandServerUrl`               | Custom Command server URL         | `Nil`                                     |
+|             Parameter                  |            Description            |                  Default                  |
+|----------------------------------------|-----------------------------------|-------------------------------------------|
+| `containerToken`                       | Sematext Container token          | `Nil` Provide your Container token        |
+| `logsToken`                            | Sematext Logs token               | `Nil` Provide your Logs token             |
+| `infraToken`                           | Sematext Infra token              | `Nil` Provide your Infra token            |
+| `region`                               | Sematext region                   | `US` Sematext US or EU region             |
+| `agent.image.repository`               | The image repository              | `sematext/agent`                          |
+| `agent.image.tag`                      | The image tag                     | `latest`                                  |
+| `agent.image.pullPolicy`               | Image pull policy                 | `Always`                                  |
+| `agent.service.port`                   | Service port                      | `80`                                      |
+| `agent.service.type`                   | Service type                      | `ClusterIP`                               |
+| `agent.resources`                      | Agent resources                   | `{}`                                      |
+| `logagent.image.repository`            | The image repository              | `sematext/logagent`                       |
+| `logagent.image.tag`                   | The image tag                     | `latest`                                  |
+| `logagent.image.pullPolicy`            | Image pull policy                 | `Always`                                  |
+| `logagent.config.LOG_GLOB`             | Set Glob for Containerd           | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#optional-parameters). |
+| `logagent.config.IGNORE_LOGS_PATTERN`  | Drops logs with a regex           | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#docker-logs-parameters). |
+| `logagent.config.MATCH_BY_NAME`        | Include logs for container name   | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#whitelist-containers-for-logging). |
+| `logagent.config.MATCH_BY_IMAGE`       | Include logs for image name       | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#whitelist-containers-for-logging). |
+| `logagent.config.SKIP_BY_NAME`         | Exclude logs for container name   | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#blacklist-containers). |
+| `logagent.config.SKIP_BY_IMAGE`        | Exclude logs for image name       | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#blacklist-containers). |
+| `logagent.config.REMOVE_FIELDS`        | Remove fields from parsed logs    | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#other-options). |
+| `logagent.resources`                   | Logagent resources                | `{}`                                      |
+| `logagent.customConfigs`               | Logagent custom configs           | `[]` Check `values.yaml`                  |
+| `logagent.extraHostVolumeMounts`       | Extra mounts                      | `{}`                                      |
+| `serviceAccount.create`                | Create a service account          | `true`                                    |
+| `serviceAccount.name`                  | Service account name              | `Nil` Defaults to chart name              |
+| `priorityClassName`                    | Priority class name               | `Nil`                                     |
+| `rbac.create`                          | RBAC enabled                      | `true`                                    |
+| `tolerations`                          | Tolerations                       | `[]`                                      |
+| `nodeSelector`                         | Node selector                     | `{}`                                      |
+| `serverBaseUrl`                        | Custom Base URL                   | `Nil`                                     |
+| `logsReceiverUrl`                      | Custom Logs receiver URL          | `Nil`                                     |
+| `eventsReceiverUrl`                    | Custom Event receiver URL         | `Nil`                                     |
+| `commandServerUrl`                     | Custom Command server URL         | `Nil`                                     |
 
 Specify each parameter using the `--set key=value` argument to `helm install`. For example:
 

--- a/charts/sematext-agent/README.md
+++ b/charts/sematext-agent/README.md
@@ -85,13 +85,13 @@ The following table lists the configuration parameters of the `sematext-agent` c
 | `logagent.image.repository`            | The image repository              | `sematext/logagent`                       |
 | `logagent.image.tag`                   | The image tag                     | `latest`                                  |
 | `logagent.image.pullPolicy`            | Image pull policy                 | `Always`                                  |
-| `logagent.config.LOG_GLOB`             | Set Glob for Containerd           | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#optional-parameters). |
-| `logagent.config.IGNORE_LOGS_PATTERN`  | Drops logs with a regex           | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#docker-logs-parameters). |
-| `logagent.config.MATCH_BY_NAME`        | Include logs for container name   | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#whitelist-containers-for-logging). |
-| `logagent.config.MATCH_BY_IMAGE`       | Include logs for image name       | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#whitelist-containers-for-logging). |
-| `logagent.config.SKIP_BY_NAME`         | Exclude logs for container name   | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#blacklist-containers). |
-| `logagent.config.SKIP_BY_IMAGE`        | Exclude logs for image name       | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#blacklist-containers). |
-| `logagent.config.REMOVE_FIELDS`        | Remove fields from parsed logs    | `Nil` Check `values.yaml`. [More Info](https://sematext.com/docs/logagent/installation-docker/#other-options). |
+| `logagent.config.LOG_GLOB`             | Set Glob for Containerd           | `Nil` Check `values.yaml`                |
+| `logagent.config.IGNORE_LOGS_PATTERN`  | Drops logs with a regex           | `Nil` Check `values.yaml`                |
+| `logagent.config.MATCH_BY_NAME`        | Include logs for container name   | `Nil` Check `values.yaml`                |
+| `logagent.config.MATCH_BY_IMAGE`       | Include logs for image name       | `Nil` Check `values.yaml`                |
+| `logagent.config.SKIP_BY_NAME`         | Exclude logs for container name   | `Nil` Check `values.yaml`                |
+| `logagent.config.SKIP_BY_IMAGE`        | Exclude logs for image name       | `Nil` Check `values.yaml`                |
+| `logagent.config.REMOVE_FIELDS`        | Remove fields from parsed logs    | `Nil` Check `values.yaml`                |
 | `logagent.resources`                   | Logagent resources                | `{}`                                      |
 | `logagent.customConfigs`               | Logagent custom configs           | `[]` Check `values.yaml`                  |
 | `logagent.extraHostVolumeMounts`       | Extra mounts                      | `{}`                                      |

--- a/charts/sematext-agent/values.yaml
+++ b/charts/sematext-agent/values.yaml
@@ -21,9 +21,20 @@ logagent:
     repository: sematext/logagent
     tag: latest
     pullPolicy: Always
+  
+  # Refer to Logagent docs for adding env vars to the config at https://sematext.com/docs/logagent/installation-docker/#configuration-parameters
+  # Any Logagent env var can be added here in the `config`.
   config:
     LOGSENE_BULK_SIZE: "1000"
     LOGSENE_LOG_INTERVAL: "10000"
+    # LOG_GLOB: "/var/log/*" # if you are using the Containerd container runtime in Kubernetes, set this value. Otherwise ignore it.
+    # IGNORE_LOGS_PATTERN: "healthcheck|ping" # Drops logs with a regular expression.
+    # MATCH_BY_NAME: ".*nginx.*" # Regular expression to include sending logs from these container names.
+    # MATCH_BY_IMAGE: ".*nginx.*" # Regular expression to include sending logs from these image names.
+    # SKIP_BY_NAME: ".*nginx.*" # Regular expression to exclude sending logs from these container names.
+    # SKIP_BY_IMAGE: ".*nginx.*" # Regular expression to exclude sending logs from these image names.
+    # REMOVE_FIELDS: "password,creditCardNo" # Removes fields from parsed/enriched logs.
+
   # Refer to logagent docs for custom config at https://sematext.com/docs/logagent/config-file/
   customConfigs: []
     # logagent.conf: |-

--- a/charts/sematext-agent/values.yaml
+++ b/charts/sematext-agent/values.yaml
@@ -22,7 +22,8 @@ logagent:
     tag: latest
     pullPolicy: Always
   
-  # Refer to Logagent docs for adding env vars to the config at https://sematext.com/docs/logagent/installation-docker/#configuration-parameters
+  # Refer to Logagent docs for adding env vars to the config at 
+  # https://sematext.com/docs/logagent/installation-docker/#configuration-parameters
   # Any Logagent env var can be added here in the `config`.
   config:
     LOGSENE_BULK_SIZE: "1000"


### PR DESCRIPTION
This PR adds additional documentation of config values for Logagent.
These values are available in the `values.yaml` or directly setting with `--set logagent.config.ENV_VAR=value`.

Values added to readme and `values.yaml`:

- `LOG_GLOB: "/var/log/*"` If you are using the Containerd container runtime in Kubernetes, set this value. Otherwise ignore it.
- `IGNORE_LOGS_PATTERN: "healthcheck|ping"` Drops logs with a regular expression.
- `MATCH_BY_NAME: ".*nginx.*"` Regular expression to include sending logs from these container names.
- `MATCH_BY_IMAGE: ".*nginx.*"` Regular expression to include sending logs from these image names.
- `SKIP_BY_NAME: ".*nginx.*"` Regular expression to exclude sending logs from these container names.
- `SKIP_BY_IMAGE: ".*nginx.*"` Regular expression to exclude sending logs from these image names.
- `REMOVE_FIELDS: "password,creditCardNo"` Removes fields from parsed/enriched logs.