### PR TITLE
allow users to provide an existing k8s secret

### DIFF
--- a/charts/sematext-agent/Chart.yaml
+++ b/charts/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.42
+version: 1.0.43
 description: Helm chart for deploying Sematext Agent and Logagent to Kubernetes
 keywords:
   - sematext

--- a/charts/sematext-agent/README.md
+++ b/charts/sematext-agent/README.md
@@ -44,6 +44,23 @@ $ helm install st-agent \
     sematext/sematext-agent
 ```
 
+To provide logs and infra tokens as a kubernetes secret instead, create a secret with `infra-token` and `logs-token` keys, and provide its name to the install command:
+
+```bash
+$ kubectl create secret generic sematext-secret \
+    --from-literal=infra-token=YOUR_INFRA_TOKEN \
+    --from-literal=logs-token=YOUR_LOGS_TOKEN
+$ helm repo add sematext https://cdn.sematext.com/helm-charts/
+$ helm install st-agent \
+    --set existingSecret.name=sematext-secret \
+    --set existingSecret.hasInfraToken=true \
+    --set existingSecret.hasLogsToken=true \
+    --set region=US \
+    sematext/sematext-agent
+```
+
+
+
 After a few minutes, you should see logs, metrics, and events reported in Sematext web UI.
 
 **NOTE:** If you want to use Sematext hosted in the EU region set the region parameter to `--set region=EU`. Also, it is worth mentioning that the agent is running as a privileged container.
@@ -72,6 +89,9 @@ The following table lists the configuration parameters of the `sematext-agent` c
 |----------------------------------------|-----------------------------------|-------------------------------------------|
 | `logsToken`                            | Sematext Logs token               | `Nil` Provide your Logs token             |
 | `infraToken`                           | Sematext Infra token              | `Nil` Provide your Infra token            |
+| `existingSecret.name`                  | Secret with infra/logs tokens     | `Nil` Provide an existing secret          |
+| `existingSecret.hasLogsToken`          | Does secret contain logs token    | `false` Enable if secret has logsToken    |
+| `existingSecret.hasInfraToken`         | Does secret contain infra token   | `false` Enable if secret has infraToken   |
 | `region`                               | Sematext region                   | `US` Sematext US or EU region             |
 | `agent.image.repository`               | The image repository              | `sematext/agent`                          |
 | `agent.image.tag`                      | The image tag                     | `latest`                                  |

--- a/charts/sematext-agent/templates/NOTES.txt
+++ b/charts/sematext-agent/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if and (not .Values.infraToken) (not .Values.logsToken) -}}
+{{- if and (not .Values.infraToken) (not .Values.logsToken) (not .Values.existingSecret.name) -}}
 
 ###############################################################################
 #           ERROR: Please provide infraToken and/or logsToken!            #
@@ -29,7 +29,7 @@ helm install st-agent \
 
 Please check the README file for all available parameters.
 
-{{- else if not .Values.logsToken -}}
+{{- else if and (not .Values.logsToken) (not .Values.existingSecret.hasLogsToken)  -}}
 
 Missing logsToken! You will only receive metrics and events.
 {{ if eq .Values.region "US" }}
@@ -38,7 +38,7 @@ After a few minutes check your app at https://apps.sematext.com/ui/monitoring
 After a few minutes check your app at https://apps.eu.sematext.com/ui/monitoring
 {{ end }}
 
-{{- else if not .Values.infraToken -}}
+{{- else if and (not .Values.infraToken) (not .Values.existingSecret.hasInfraToken) -}}
 
 Missing infraToken! You will only receive logs.
 {{ if eq .Values.region "US" }}

--- a/charts/sematext-agent/templates/clusterrole.yaml
+++ b/charts/sematext-agent/templates/clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
   - list
   - get
   - watch
-{{- if .Values.infraToken }}
+{{- if or (.Values.infraToken) (.Values.existingSecret.hasInfraToken) }}
 - apiGroups:
   - ""
   resources:

--- a/charts/sematext-agent/templates/daemonset.yaml
+++ b/charts/sematext-agent/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.infraToken) (.Values.logsToken) }}
+{{- if or (.Values.infraToken) (.Values.logsToken) (.Values.existingSecret.name) }}
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else }}
@@ -33,7 +33,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       containers:
-        {{- if .Values.infraToken }}
+        {{- if or (.Values.infraToken) (.Values.existingSecret.hasInfraToken) }}
         - name: agent
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
@@ -41,12 +41,12 @@ spec:
           - name: INFRA_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "sematext-agent.fullname" . }}
+                name: {{ default (include "sematext-agent.fullname" .) .Values.existingSecret.name }}
                 key: infra-token
           - name: LOGS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "sematext-agent.fullname" . }}
+                name: {{ default (include "sematext-agent.fullname" .) .Values.existingSecret.name }}
                 key: logs-token
           - name: STA_NAMESPACE
             valueFrom:
@@ -101,7 +101,7 @@ spec:
           resources:
 {{ toYaml .Values.agent.resources | indent 12 }}
         {{- end }}
-        {{- if .Values.logsToken }}
+        {{- if or (.Values.logsToken) (.Values.existingSecret.hasLogsToken) }}
         - name: logagent
           image: "{{ .Values.logagent.image.repository }}:{{ .Values.logagent.image.tag }}"
           imagePullPolicy: {{ .Values.logagent.image.pullPolicy }}
@@ -109,7 +109,7 @@ spec:
           - name: LOGS_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "sematext-agent.fullname" . }}
+                name: {{ default (include "sematext-agent.fullname" .) .Values.existingSecret.name }}
                 key: logs-token
           envFrom:
           - configMapRef:
@@ -173,3 +173,4 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
+

--- a/charts/sematext-agent/templates/daemonset.yaml
+++ b/charts/sematext-agent/templates/daemonset.yaml
@@ -43,11 +43,13 @@ spec:
               secretKeyRef:
                 name: {{ default (include "sematext-agent.fullname" .) .Values.existingSecret.name }}
                 key: infra-token
+          {{- if or (.Values.logsToken) (.Values.existingSecret.hasLogsToken) }}
           - name: LOGS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ default (include "sematext-agent.fullname" .) .Values.existingSecret.name }}
                 key: logs-token
+          {{- end }}
           - name: STA_NAMESPACE
             valueFrom:
               fieldRef:

--- a/charts/sematext-agent/templates/secret.yaml
+++ b/charts/sematext-agent/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ type: Opaque
 data:
   infra-token: {{ default "" .Values.infraToken | b64enc | quote }}
   logs-token: {{ default "" .Values.logsToken | b64enc | quote }}
+{{- end }}

--- a/charts/sematext-agent/values.yaml
+++ b/charts/sematext-agent/values.yaml
@@ -78,6 +78,11 @@ serviceAccount:
 infraToken: null
 # logs token to send logs
 logsToken: null
+# instead of providing them directly, provide an existing secret from which infra token and logs token will be read (mutually exclusive with infraToken and logsToken)
+existingSecret:
+  name: null
+  hasLogsToken: false
+  hasInfraToken: false
 
 # for private images
 # imagePullSecrets:


### PR DESCRIPTION
Hello, we are installing our helm charts using gitops, and we need a way to provide infra/logs token without specifying them in values directly (as this would require us to commit them to git).

I've adapted the chart so we can use it and i'm creating a PR with the same changes to see if this is something that you guys would like to have in the main chart.

Let me know what you think :)