### PR TITLE
[SC-20067] fix(sta): autodiscover from all namespaces by default

### DIFF
--- a/charts/sematext-agent/values.yaml
+++ b/charts/sematext-agent/values.yaml
@@ -15,7 +15,6 @@ agent:
     API_SERVER_HOST: 0.0.0.0
     LOGGING_WRITE_EVENTS: false
     LOGGING_REQUEST_TRACKING: false
-    AUTODISCO_ALLOWED_NAMESPACES: "default"
     LOGGING_LEVEL: info
   resources:
       limits:


### PR DESCRIPTION
When len(AUTODISCO_ALLOWED_NAMESPACES) == 0. All namespaces are queried by default